### PR TITLE
fix: pontuaction error

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,15 +36,15 @@ function addSuffixes(newSuffixes) {
 /**
  *
  * @param {string} string
- * @param {integer} total
+ * @param {integer} total - default 0
  * @description Parses a string to an integer
  * @example specialArg('10%', 1000) // 100
  * @returns {integer}
  */
-function numerize(string, total) {
+function numerize(string, total = 0) {
 	string = string.toLowerCase()
-	string.replace(/,/g, "")
-	string.replace(/\./g, "")
+	string = string.replace(/,/g, "")
+	string = string.replace(/\./g, "")
 	var new_value = parseInt(string)
 
 	if (string in words) {


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where 1,000 or 1.000 where read as 1 instead of 1000

## Summary of changes
- numerize function now receives the results from the replace functions
- numerize function now has its second argument optional

## Checklist
<!-- Check the boxes that apply to this PR using "x" -->
- [x] These changes have been tested and formatted properly.
- [x] These changes also include the change in documentation accordingly.
- [ ] This PR introduces some breaking changes.
